### PR TITLE
Separate bg-secondary for light and dark modes

### DIFF
--- a/scripts/update-colors.js
+++ b/scripts/update-colors.js
@@ -13,11 +13,11 @@ const path = require('path');
 // Mapping warna lama ke baru
 const colorMappings = {
   // Background
-  'bg-white': 'bg-bg-secondary',
-  'dark:bg-gray-800': 'dark:bg-bg-primary',
-  'dark:bg-gray-900': 'dark:bg-bg-primary',
-  'bg-gray-100': 'bg-bg-secondary/50',
-  'dark:bg-gray-700': 'dark:bg-bg-secondary/10',
+  'bg-white': 'bg-bg-secondary-light',
+  'dark:bg-gray-800': 'dark:bg-bg-secondary-dark',
+  'dark:bg-gray-900': 'dark:bg-bg-secondary-dark',
+  'bg-gray-100': 'bg-bg-secondary-light/50',
+  'dark:bg-gray-700': 'dark:bg-bg-secondary-dark/10',
   
   // Text
   'text-gray-900': 'text-text-secondary',
@@ -30,12 +30,12 @@ const colorMappings = {
   'dark:text-gray-200': 'dark:text-text-primary',
   
   // Borders
-  'border-gray-200': 'border-bg-secondary',
-  'dark:border-gray-700': 'dark:border-bg-secondary/20',
+  'border-gray-200': 'border-bg-secondary-light',
+  'dark:border-gray-700': 'dark:border-bg-secondary-dark/20',
   
   // Hover states
-  'hover:bg-gray-100': 'hover:bg-bg-secondary/50',
-  'dark:hover:bg-gray-700': 'dark:hover:bg-bg-secondary/10',
+  'hover:bg-gray-100': 'hover:bg-bg-secondary-light/50',
+  'dark:hover:bg-gray-700': 'dark:hover:bg-bg-secondary-dark/10',
   
   // Buttons
   'bg-primary': 'bg-cta-primary',

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -16,7 +16,7 @@ export default function DashboardPage() {
 
         {/* Stats Grid */}
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-3 lg:gap-4">
-          <Card className="bg-bg-secondary dark:bg-bg-tertiary border-border-primary hover:shadow-lg transition-shadow">
+          <Card className="bg-bg-secondary-light dark:bg-bg-secondary-dark border-border-primary hover:shadow-lg transition-shadow">
             <CardContent className="p-2 sm:p-3 lg:p-4">
               <div className="flex items-center justify-between">
                 <div className="flex-1 min-w-0">
@@ -34,7 +34,7 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
-          <Card className="bg-bg-secondary dark:bg-bg-tertiary border-border-primary hover:shadow-lg transition-shadow">
+          <Card className="bg-bg-secondary-light dark:bg-bg-secondary-dark border-border-primary hover:shadow-lg transition-shadow">
             <CardContent className="p-2 sm:p-3 lg:p-4">
               <div className="flex items-center justify-between">
                 <div className="flex-1 min-w-0">
@@ -52,7 +52,7 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
-          <Card className="bg-bg-secondary dark:bg-bg-tertiary border-border-primary hover:shadow-lg transition-shadow">
+          <Card className="bg-bg-secondary-light dark:bg-bg-secondary-dark border-border-primary hover:shadow-lg transition-shadow">
             <CardContent className="p-2 sm:p-3 lg:p-4">
               <div className="flex items-center justify-between">
                 <div className="flex-1 min-w-0">
@@ -69,7 +69,7 @@ export default function DashboardPage() {
             </CardContent>
           </Card>
 
-          <Card className="bg-bg-secondary dark:bg-bg-tertiary border-border-primary hover:shadow-lg transition-shadow">
+          <Card className="bg-bg-secondary-light dark:bg-bg-secondary-dark border-border-primary hover:shadow-lg transition-shadow">
             <CardContent className="p-2 sm:p-3 lg:p-4">
               <div className="flex items-center justify-between">
                 <div className="flex-1 min-w-0">
@@ -89,7 +89,7 @@ export default function DashboardPage() {
         </div>
 
         {/* Quick Actions */}
-        <Card className="bg-bg-secondary dark:bg-bg-tertiary border-border-primary hover:shadow-lg transition-shadow">
+        <Card className="bg-bg-secondary-light dark:bg-bg-secondary-dark border-border-primary hover:shadow-lg transition-shadow">
           <CardHeader className="pb-2 sm:pb-3">
             <h2 className="text-base sm:text-lg lg:text-xl font-semibold text-text-primary">Quick Actions</h2>
           </CardHeader>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,8 @@
   --background: #ffffff;
   --foreground: #1E2026;
   --bg-primary: #ffffff;
-  --bg-secondary: #FAFAFA;
+  --bg-secondary-light: #FAFAFA;
+  --bg-secondary-dark: #1E2026;
   --bg-tertiary: #F5F5F5;
   --cta-primary: #F0B90B;
   --cta-secondary: #FCD535;
@@ -33,7 +34,8 @@
     --background: #0C0E12;
     --foreground: #EAECEF;
     --bg-primary: #0C0E12;
-    --bg-secondary: #1E2026;
+    --bg-secondary-light: #FAFAFA;
+    --bg-secondary-dark: #1E2026;
     --bg-tertiary: #2B2F36;
     --cta-primary: #F0B90B;
     --cta-secondary: #FCD535;
@@ -55,7 +57,8 @@
   --background: #0C0E12;
   --foreground: #EAECEF;
   --bg-primary: #0C0E12;
-  --bg-secondary: #1E2026;
+  --bg-secondary-light: #FAFAFA;
+  --bg-secondary-dark: #1E2026;
   --bg-tertiary: #2B2F36;
   --cta-primary: #F0B90B;
   --cta-secondary: #FCD535;
@@ -122,7 +125,7 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--bg-secondary);
+  background: var(--bg-secondary-light);
 }
 
 ::-webkit-scrollbar-thumb {

--- a/src/components/dashboard/DashboardContent.tsx
+++ b/src/components/dashboard/DashboardContent.tsx
@@ -11,7 +11,7 @@ function getStatusClass(status: string) {
     case 'Partial':
       return 'bg-cta-primary/20 text-text-secondary dark:text-text-primary';
     default:
-      return 'bg-bg-secondary/50 text-text-secondary dark:text-text-primary';
+      return 'bg-bg-secondary-light/50 dark:bg-bg-secondary-dark/50 text-text-secondary dark:text-text-primary';
   }
 }
 
@@ -26,42 +26,42 @@ export default function DashboardContent() {
       
       {/* Balance Cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 sm:gap-4 lg:gap-6">
-        <div className="bg-bg-secondary dark:bg-bg-primary rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary dark:border-bg-secondary/20">
+        <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary-light dark:border-bg-secondary-dark/20">
           <div className="text-xs sm:text-sm text-text-secondary/60 dark:text-text-primary/60">Total Balance</div>
           <div className="text-lg sm:text-xl lg:text-2xl font-bold text-text-secondary dark:text-text-primary">${balance.totalUSDT.toLocaleString()}</div>
         </div>
-        <div className="bg-bg-secondary dark:bg-bg-primary rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary dark:border-bg-secondary/20">
+        <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary-light dark:border-bg-secondary-dark/20">
           <div className="text-xs sm:text-sm text-text-secondary/60 dark:text-text-primary/60">Bitcoin</div>
           <div className="text-base sm:text-lg lg:text-xl font-bold text-text-secondary dark:text-text-primary">{balance.btc.amount} BTC</div>
           <div className="text-xs sm:text-sm text-text-secondary/60 dark:text-text-primary/60">≈ ${balance.btc.value.toLocaleString()}</div>
         </div>
-        <div className="bg-bg-secondary dark:bg-bg-primary rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary dark:border-bg-secondary/20">
+        <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary-light dark:border-bg-secondary-dark/20">
           <div className="text-xs sm:text-sm text-text-secondary/60 dark:text-text-primary/60">Ethereum</div>
           <div className="text-base sm:text-lg lg:text-xl font-bold text-text-secondary dark:text-text-primary">{balance.eth.amount} ETH</div>
           <div className="text-xs sm:text-sm text-text-secondary/60 dark:text-text-primary/60">≈ ${balance.eth.value.toLocaleString()}</div>
         </div>
-        <div className="bg-bg-secondary dark:bg-bg-primary rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary dark:border-bg-secondary/20">
+        <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary-light dark:border-bg-secondary-dark/20">
           <div className="text-xs sm:text-sm text-text-secondary/60 dark:text-text-primary/60">USDT</div>
           <div className="text-base sm:text-lg lg:text-xl font-bold text-text-secondary dark:text-text-primary">{balance.usdt} USDT</div>
         </div>
       </div>
 
       {/* Chart Placeholder */}
-      <div className="bg-bg-secondary dark:bg-bg-primary rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary dark:border-bg-secondary/20">
+      <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg p-3 sm:p-4 lg:p-6 shadow-sm border border-bg-secondary-light dark:border-bg-secondary-dark/20">
         <h3 className="text-base sm:text-lg font-semibold text-text-secondary dark:text-text-primary mb-3 sm:mb-4">Portfolio Performance</h3>
-        <div className="h-48 sm:h-64 bg-bg-secondary/50 dark:bg-bg-secondary/10 rounded-lg flex items-center justify-center">
+        <div className="h-48 sm:h-64 bg-bg-secondary-light/50 dark:bg-bg-secondary-dark/10 rounded-lg flex items-center justify-center">
           <span className="text-xs sm:text-sm text-text-secondary/60 dark:text-text-primary/60">Chart akan ditampilkan di sini</span>
         </div>
       </div>
 
       {/* Recent Trades */}
-      <div className="bg-bg-secondary dark:bg-bg-primary rounded-lg shadow-sm border border-bg-secondary dark:border-bg-secondary/20">
-        <div className="p-3 sm:p-4 lg:p-6 border-b border-bg-secondary dark:border-bg-secondary/20">
+      <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg shadow-sm border border-bg-secondary-light dark:border-bg-secondary-dark/20">
+        <div className="p-3 sm:p-4 lg:p-6 border-b border-bg-secondary-light dark:border-bg-secondary-dark/20">
           <h3 className="text-base sm:text-lg font-semibold text-text-secondary dark:text-text-primary">Recent Trades</h3>
         </div>
         <div className="overflow-x-auto">
           <table className="w-full">
-            <thead className="bg-bg-secondary/50 dark:bg-bg-secondary/10">
+            <thead className="bg-bg-secondary-light/50 dark:bg-bg-secondary-dark/10">
               <tr>
                 <th className="px-2 sm:px-4 lg:px-6 py-2 sm:py-3 text-left text-xs font-medium text-text-secondary/60 dark:text-text-primary/60 uppercase tracking-wider">Date</th>
                 <th className="px-2 sm:px-4 lg:px-6 py-2 sm:py-3 text-left text-xs font-medium text-text-secondary/60 dark:text-text-primary/60 uppercase tracking-wider">Pair</th>
@@ -72,7 +72,7 @@ export default function DashboardContent() {
                 <th className="px-2 sm:px-4 lg:px-6 py-2 sm:py-3 text-left text-xs font-medium text-text-secondary/60 dark:text-text-primary/60 uppercase tracking-wider">Status</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-bg-secondary dark:divide-bg-secondary/20">
+            <tbody className="divide-y divide-bg-secondary-light dark:divide-bg-secondary-dark/20">
               {recentTrades.map((trade, index) => (
                 <tr key={index}>
                   <td className="px-2 sm:px-4 lg:px-6 py-2 sm:py-4 whitespace-nowrap text-xs sm:text-sm text-text-secondary dark:text-text-primary">{trade.date}</td>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,7 +11,7 @@ export default function Header({ onMenuClick }: HeaderProps) {
   const [notifications] = useState(3);
 
   return (
-    <header className="bg-bg-secondary border-b border-border-primary shadow-sm sticky top-0 z-30">
+    <header className="bg-bg-secondary-light dark:bg-bg-secondary-dark border-b border-border-primary shadow-sm sticky top-0 z-30">
       <div className="flex items-center justify-between px-4 py-4 lg:px-6">
         {/* Left Section */}
         <div className="flex items-center space-x-4">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -68,7 +68,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
     <>
       {/* Mobile Sidebar - Fully opaque */}
       <div className={`
-        fixed inset-y-0 left-0 z-50 w-72 sm:w-80 bg-bg-secondary border-r border-border-primary
+        fixed inset-y-0 left-0 z-50 w-72 sm:w-80 bg-bg-secondary-light dark:bg-bg-secondary-dark border-r border-border-primary
         transform transition-transform duration-300 ease-in-out lg:hidden
         ${isOpen ? 'translate-x-0' : '-translate-x-full'}
         shadow-2xl
@@ -146,7 +146,7 @@ export default function Sidebar({ isOpen, onClose }: SidebarProps) {
       </div>
 
       {/* Desktop Sidebar */}
-      <aside className="hidden lg:block w-80 bg-bg-secondary border-r border-border-primary h-screen sticky top-0">
+      <aside className="hidden lg:block w-80 bg-bg-secondary-light dark:bg-bg-secondary-dark border-r border-border-primary h-screen sticky top-0">
         <div className="h-full overflow-y-auto">
           <div className="p-6 space-y-6">
             {/* Logo/Brand */}

--- a/src/components/markets/MarketsContent.tsx
+++ b/src/components/markets/MarketsContent.tsx
@@ -9,13 +9,13 @@ export default function MarketsContent() {
         <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-text-primary mb-4 sm:mb-6">Markets</h1>
       </div>
       
-      <div className="bg-bg-secondary dark:bg-bg-tertiary rounded-lg shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
+      <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
         <div className="p-4 sm:p-6 border-b border-border-primary">
           <h3 className="text-base sm:text-lg font-semibold text-text-primary">Cryptocurrency Markets</h3>
         </div>
         <div className="overflow-x-auto">
           <table className="w-full">
-            <thead className="bg-bg-primary dark:bg-bg-secondary">
+            <thead className="bg-bg-primary dark:bg-bg-secondary-dark">
               <tr>
                 <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-text-tertiary uppercase tracking-wider">Symbol</th>
                 <th className="px-3 sm:px-6 py-3 text-left text-xs font-medium text-text-tertiary uppercase tracking-wider">Price</th>
@@ -26,7 +26,7 @@ export default function MarketsContent() {
             </thead>
             <tbody className="divide-y divide-border-primary">
               {mockData.markets.map((market, index) => (
-                <tr key={index} className="hover:bg-bg-primary dark:hover:bg-bg-secondary transition-colors">
+                <tr key={index} className="hover:bg-bg-primary dark:hover:bg-bg-secondary-dark transition-colors">
                   <td className="px-3 sm:px-6 py-4 whitespace-nowrap">
                     <div className="text-sm font-medium text-text-primary">{market.symbol}</div>
                   </td>

--- a/src/components/trade/TradeContent.tsx
+++ b/src/components/trade/TradeContent.tsx
@@ -14,7 +14,7 @@ export default function TradeContent() {
       </div>
       
       {/* Trading Pair Selector */}
-      <div className="bg-bg-secondary dark:bg-bg-tertiary rounded-lg p-4 shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
+      <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg p-4 shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
         <div className="flex flex-wrap gap-2">
           {tradingPairs.map((pair) => (
             <button
@@ -23,7 +23,7 @@ export default function TradeContent() {
               className={`px-3 sm:px-4 py-2 rounded-lg text-sm transition-colors ${
                 selectedPair === pair
                   ? 'bg-cta-primary text-text-secondary'
-                  : 'bg-bg-primary dark:bg-bg-secondary text-text-secondary hover:bg-bg-tertiary dark:hover:bg-bg-primary'
+                  : 'bg-bg-primary dark:bg-bg-secondary-dark text-text-secondary hover:bg-bg-tertiary dark:hover:bg-bg-primary'
               }`}
             >
               {pair}
@@ -33,9 +33,9 @@ export default function TradeContent() {
       </div>
 
       {/* Chart */}
-      <div className="bg-bg-secondary dark:bg-bg-tertiary rounded-lg p-4 sm:p-6 shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
+      <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg p-4 sm:p-6 shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
         <h3 className="text-base sm:text-lg font-semibold text-text-primary mb-4">{selectedPair} Chart</h3>
-        <div className="h-64 sm:h-96 bg-bg-primary dark:bg-bg-secondary rounded-lg flex items-center justify-center">
+        <div className="h-64 sm:h-96 bg-bg-primary dark:bg-bg-secondary-dark rounded-lg flex items-center justify-center">
           <span className="text-text-tertiary text-sm sm:text-base">Trading chart akan ditampilkan di sini</span>
         </div>
       </div>
@@ -43,12 +43,12 @@ export default function TradeContent() {
       {/* Trading Section */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
         {/* Buy Section */}
-        <div className="bg-bg-secondary dark:bg-bg-tertiary rounded-lg p-4 sm:p-6 shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
+        <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg p-4 sm:p-6 shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
           <h3 className="text-base sm:text-lg font-semibold text-success mb-4">Buy {selectedPair.split('/')[0]}</h3>
           <div className="space-y-3 sm:space-y-4">
             <div>
               <label className="block text-sm font-medium text-text-secondary mb-2">Order Type</label>
-              <select className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary text-text-primary">
+              <select className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary-dark text-text-primary">
                 <option>Limit Order</option>
                 <option>Market Order</option>
                 <option>Stop Limit</option>
@@ -56,11 +56,11 @@ export default function TradeContent() {
             </div>
             <div>
               <label className="block text-sm font-medium text-text-secondary mb-2">Price (USDT)</label>
-              <input type="number" placeholder="36,789.45" className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary text-text-primary" />
+              <input type="number" placeholder="36,789.45" className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary-dark text-text-primary" />
             </div>
             <div>
               <label className="block text-sm font-medium text-text-secondary mb-2">Amount ({selectedPair.split('/')[0]})</label>
-              <input type="number" placeholder="0.001" className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary text-text-primary" />
+              <input type="number" placeholder="0.001" className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary-dark text-text-primary" />
             </div>
             <div>
               <label className="block text-sm font-medium text-text-secondary mb-2">Total (USDT)</label>
@@ -73,12 +73,12 @@ export default function TradeContent() {
         </div>
 
         {/* Sell Section */}
-        <div className="bg-bg-secondary dark:bg-bg-tertiary rounded-lg p-4 sm:p-6 shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
+        <div className="bg-bg-secondary-light dark:bg-bg-secondary-dark rounded-lg p-4 sm:p-6 shadow-sm border border-border-primary hover:shadow-lg transition-shadow">
           <h3 className="text-base sm:text-lg font-semibold text-danger mb-4">Sell {selectedPair.split('/')[0]}</h3>
           <div className="space-y-3 sm:space-y-4">
             <div>
               <label className="block text-sm font-medium text-text-secondary mb-2">Order Type</label>
-              <select className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary text-text-primary">
+              <select className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary-dark text-text-primary">
                 <option>Limit Order</option>
                 <option>Market Order</option>
                 <option>Stop Limit</option>
@@ -86,11 +86,11 @@ export default function TradeContent() {
             </div>
             <div>
               <label className="block text-sm font-medium text-text-secondary mb-2">Price (USDT)</label>
-              <input type="number" placeholder="36,789.45" className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary text-text-primary" />
+              <input type="number" placeholder="36,789.45" className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary-dark text-text-primary" />
             </div>
             <div>
               <label className="block text-sm font-medium text-text-secondary mb-2">Amount ({selectedPair.split('/')[0]})</label>
-              <input type="number" placeholder="0.001" className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary text-text-primary" />
+              <input type="number" placeholder="0.001" className="w-full px-3 py-2 text-sm sm:text-base border border-border-primary rounded-lg focus:ring-2 focus:ring-cta-primary/20 focus:border-cta-primary bg-bg-primary dark:bg-bg-secondary-dark text-text-primary" />
             </div>
             <div>
               <label className="block text-sm font-medium text-text-secondary mb-2">Total (USDT)</label>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -17,8 +17,8 @@ export default function Button({
   
   const variantClasses = {
     primary: 'bg-gradient-primary text-text-secondary hover:shadow-lg hover:scale-105 focus:ring-cta-primary/20',
-    secondary: 'bg-bg-secondary text-text-primary border border-border-primary hover:bg-bg-tertiary focus:ring-border-primary/20',
-    outline: 'bg-transparent text-text-primary border border-border-primary hover:bg-bg-secondary focus:ring-border-primary/20',
+    secondary: 'bg-bg-secondary-light dark:bg-bg-secondary-dark text-text-primary border border-border-primary hover:bg-bg-tertiary focus:ring-border-primary/20',
+    outline: 'bg-transparent text-text-primary border border-border-primary hover:bg-bg-secondary-light dark:hover:bg-bg-secondary-dark focus:ring-border-primary/20',
     ghost: 'bg-transparent text-text-secondary hover:bg-bg-tertiary hover:text-text-primary focus:ring-border-primary/20',
     danger: 'bg-danger text-white hover:bg-danger/90 focus:ring-danger/20',
   };

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -26,7 +26,8 @@ export const COLORS = {
 // Tailwind class mappings
 export const COLOR_CLASSES = {
   bgPrimary: 'bg-bg-primary',
-  bgSecondary: 'bg-bg-secondary',
+  bgSecondaryLight: 'bg-bg-secondary-light',
+  bgSecondaryDark: 'bg-bg-secondary-dark',
   ctaPrimary: 'bg-cta-primary',
   ctaSecondary: 'bg-cta-secondary',
   textPrimary: 'text-text-primary',
@@ -38,7 +39,8 @@ export const COLOR_CLASSES = {
 // Dark mode specific classes
 export const DARK_MODE_CLASSES = {
   bgPrimary: 'dark:bg-bg-primary',
-  bgSecondary: 'dark:bg-bg-secondary',
+  bgSecondaryLight: 'dark:bg-bg-secondary-light',
+  bgSecondaryDark: 'dark:bg-bg-secondary-dark',
   textPrimary: 'dark:text-text-primary',
   textSecondary: 'dark:text-text-secondary',
 } as const;
@@ -46,8 +48,8 @@ export const DARK_MODE_CLASSES = {
 // Common component color combinations
 export const COMPONENT_COLORS = {
   card: {
-    background: 'bg-bg-secondary dark:bg-bg-primary',
-    border: 'border-bg-secondary dark:border-bg-secondary/20',
+    background: 'bg-bg-secondary-light dark:bg-bg-secondary-dark',
+    border: 'border-bg-secondary-light dark:border-bg-secondary-dark/20',
     text: 'text-text-secondary dark:text-text-primary',
     textMuted: 'text-text-secondary/60 dark:text-text-primary/60',
   },
@@ -57,8 +59,8 @@ export const COMPONENT_COLORS = {
     outline: 'border border-cta-primary text-cta-primary hover:bg-cta-primary/10',
   },
   input: {
-    background: 'bg-bg-secondary dark:bg-bg-primary',
-    border: 'border-bg-secondary dark:border-bg-secondary/20',
+    background: 'bg-bg-secondary-light dark:bg-bg-secondary-dark',
+    border: 'border-bg-secondary-light dark:border-bg-secondary-dark/20',
     text: 'text-text-secondary dark:text-text-primary',
     placeholder: 'placeholder-text-secondary/60 dark:placeholder-text-primary/60',
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,7 +12,8 @@ const config: Config = {
       colors: {
         // Binance-inspired color scheme
         'bg-primary': 'var(--bg-primary)',
-        'bg-secondary': 'var(--bg-secondary)',
+        'bg-secondary-light': 'var(--bg-secondary-light)',
+        'bg-secondary-dark': 'var(--bg-secondary-dark)',
         'bg-tertiary': 'var(--bg-tertiary)',
         'cta-primary': 'var(--cta-primary)',
         'cta-secondary': 'var(--cta-secondary)',


### PR DESCRIPTION
Separate `bg-secondary` into light and dark mode variables and update all usages.

This change ensures the `bg-secondary` color correctly adapts to light and dark themes, resolving display inconsistencies when switching modes.

---
<a href="https://cursor.com/background-agent?bcId=bc-dda4fc86-44bd-4fae-b51f-a27a932f3680">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dda4fc86-44bd-4fae-b51f-a27a932f3680">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

